### PR TITLE
fixed typo

### DIFF
--- a/R/model-pgls.R
+++ b/R/model-pgls.R
@@ -170,7 +170,7 @@ make.all.branches.pgls.contrasts <- function(cache, control) {
 
 check.data.pgls <- function(tree, formula, data, allow.unnamed=FALSE) {
   if (!inherits(formula, "formula"))
-    stop("'formula' must be a formua object")
+    stop("'formula' must be a formula object")
   if (!is.data.frame(data))
     stop("'data' must be a data.frame")
 


### PR DESCRIPTION
There is a small typo in the error message for `make.pgls`.  I noticed when used this function (Thanks for the great work).