### PR TITLE
Properly pass GSL flags to configure when GSL is installed outside of /usr/local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ src/Makevars
 src/config.h
 config.log
 
+src/*.o
+src/*.so
 diversitree/config.log
 diversitree/src/*.o
 diversitree/src/*.so

--- a/configure
+++ b/configure
@@ -3281,6 +3281,9 @@ else
    as_fn_error $? "gsl-config not found, is GSL installed?" "$LINENO" 5
 fi
 
+CPPFLAGS="${CPPFLAGS} ${GSL_CFLAGS}"
+PKG_LIBS="${PKG_LIBS} ${GSL_LIBS}"
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if GSL version >= 1.15" >&5
 $as_echo_n "checking if GSL version >= 1.15... " >&6; }
 if test "$cross_compiling" = yes; then :

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,9 @@ else
    AC_MSG_ERROR([gsl-config not found, is GSL installed?])
 fi
 
+CPPFLAGS="${CPPFLAGS} ${GSL_CFLAGS}"
+PKG_LIBS="${PKG_LIBS} ${GSL_LIBS}"
+
 AC_MSG_CHECKING([if GSL version >= 1.15])
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>


### PR DESCRIPTION
On macOS ARM, a Homebrew installation of GSL is located in /opt/homebrew/. The current configure script fails to use the output of `gsl-config --cflags` in its test, which fails with:

```console
% make install
* installing to library ‘/Library/Frameworks/R.framework/Versions/4.1-arm64/Resources/library’
* installing *source* package ‘diversitree’ ...
** using staged installation
checking for gcc... clang -arch arm64
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether clang -arch arm64 accepts -g... yes
checking for clang -arch arm64 option to accept ISO C89... none needed
checking how to run the C preprocessor... clang -arch arm64 -E
checking for grep that handles long lines and -e... /opt/homebrew/bin/ggrep
checking for egrep... /opt/homebrew/bin/ggrep -E
checking for ANSI C header files... rm: conftest.dSYM: is a directory
rm: conftest.dSYM: is a directory
yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking fftw3.h usability... no
checking fftw3.h presence... no
checking for fftw3.h... no
configure: WARNING: No fftw found - QuaSSE/fftC will not be available
checking for gsl-config... /opt/homebrew/bin/gsl-config
checking if GSL version >= 1.15... configure: error: Need GSL version >= 1.15
ERROR: configuration failed for package ‘diversitree’
```

This is fixed by setting `CPPFLAGS` in configure.ac and running autoreconf with autoconf 2.69.

I also ignore .so and .o files in src/.