### PR TITLE
Fix bug with optimizing birth-death models using only branching times

### DIFF
--- a/R/model-bd-nee.R
+++ b/R/model-bd-nee.R
@@ -4,7 +4,8 @@ make.cache.bd.nee <- function(tree=NULL, sampling.f=NULL,
   if ( !is.null(sampling.f) && !is.null(unresolved) )
     stop("Cannot specify both sampling.f and unresolved")
   sampling.f <- check.sampling.f(sampling.f, 1)
-  unresolved <- check.unresolved.bd(tree, unresolved)
+  if ( !is.null(tree) && !is.null(unresolved) )
+    unresolved <- check.unresolved.bd(tree, unresolved)
 
   if ( is.null(times) ) { # proper tree
     tree <- check.tree(tree)

--- a/R/model-bd.R
+++ b/R/model-bd.R
@@ -13,7 +13,7 @@
 ##   stationary.freq
 ##   starting.point
 ##   branches
-make.bd <- function(tree, sampling.f=NULL, unresolved=NULL,
+make.bd <- function(tree=NULL, sampling.f=NULL, unresolved=NULL,
                     times=NULL, control=list()) {
   control <- check.control.bd(control, times)
   cache <- make.cache.bd(tree, sampling.f, unresolved, times, control)
@@ -40,7 +40,7 @@ make.bd <- function(tree, sampling.f=NULL, unresolved=NULL,
 ## Yule is somewhat weird, as we allow likelihood calculations, but
 ## cheat on the ML search and go straight for the ML point.  Well, we
 ## used to, but that is currently broken.
-make.yule <- function(tree, sampling.f=NULL, unresolved=NULL,
+make.yule <- function(tree=NULL, sampling.f=NULL, unresolved=NULL,
                       times=NULL, control=list()) {
   control <- check.control.bd(control)
   ll.bd <- make.bd(tree, sampling.f, unresolved, times, control)


### PR DESCRIPTION
The documentation suggests that one can optimize a vector of branching times by only passing `times = ` to `make.bd` or `make.yule`. However, there are a few bugs that prevent this.

```console
> make.bd(times = 1:3, sampling.f = 0.5)
Error in make.cache.bd(tree, sampling.f, unresolved, times, control) : 
  argument "tree" is missing, with no default
```

This is fixed by changing the prototypes of `make.bd` and `make.yule`.

If we try to pass `tree = NULL`:

```console
> make.bd(tree = NULL, times = 1:3, sampling.f = 0.5)
Error in check.unresolved.bd(tree, unresolved) : 
  Cannot just specify times when using unresolved clades
```

This is fixed by adding a guard to see if `unresolved = NULL`.